### PR TITLE
Add an error threshold to better bail/warn on hard failures

### DIFF
--- a/osu.Server.QueueProcessor/GracefulShutdownSource.cs
+++ b/osu.Server.QueueProcessor/GracefulShutdownSource.cs
@@ -12,6 +12,8 @@ namespace osu.Server.QueueProcessor
 
         private readonly CancellationTokenSource cts;
 
+        public void Cancel() => cts.Cancel();
+
         public GracefulShutdownSource(in CancellationToken cancellation = default)
         {
             cts = CancellationTokenSource.CreateLinkedTokenSource(cancellation);

--- a/osu.Server.QueueProcessor/QueueConfiguration.cs
+++ b/osu.Server.QueueProcessor/QueueConfiguration.cs
@@ -21,5 +21,13 @@ namespace osu.Server.QueueProcessor
         /// The number of times to re-queue a failed item for another attempt.
         /// </summary>
         public int MaxRetries { get; set; } = 3;
+
+        /// <summary>
+        /// The maximum number of recent errors before exiting with an error.
+        /// </summary>
+        /// <remarks>
+        /// Every error will increment an internal count, while every success will decrement it.
+        /// </remarks>
+        public int ErrorThreshold { get; set; } = 10;
     }
 }


### PR DESCRIPTION
Avoid one bad queue processor eating all items without remorse.