### PR TITLE
Allow `QueueItem`s to have tags for datadog metric reporting purposes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.102
+          dotnet-version: "6.0.x"
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/osu.Server.QueueProcessor/QueueItem.cs
+++ b/osu.Server.QueueProcessor/QueueItem.cs
@@ -11,7 +11,7 @@ namespace osu.Server.QueueProcessor
     [Serializable]
     public abstract class QueueItem
     {
-        public int TotalRetries { get; internal set; }
+        public int TotalRetries { get; set; }
 
         /// <summary>
         /// Tags which will be used for tracking a processed item.

--- a/osu.Server.QueueProcessor/QueueItem.cs
+++ b/osu.Server.QueueProcessor/QueueItem.cs
@@ -11,6 +11,6 @@ namespace osu.Server.QueueProcessor
     [Serializable]
     public abstract class QueueItem
     {
-        public int TotalRetries { get; set; }
+        public int TotalRetries { get; internal set; }
     }
 }

--- a/osu.Server.QueueProcessor/QueueItem.cs
+++ b/osu.Server.QueueProcessor/QueueItem.cs
@@ -12,5 +12,10 @@ namespace osu.Server.QueueProcessor
     public abstract class QueueItem
     {
         public int TotalRetries { get; internal set; }
+
+        /// <summary>
+        /// Tags which will be used for tracking a processed item.
+        /// </summary>
+        public string[]? Tags { get; set; }
     }
 }


### PR DESCRIPTION
I've started to show lazer score submission metrics on datadog (see https://status.ppy.sh) but it's not possible to distinguish new scores from reprocessed or "upgraded" scores. I'd like to add tracking of each kind for the public display, but also add better monitoring on the process (to account for cases it falls over, like it did on the weekend).

Rather than duplicating the reported increments to datadog, it makes sense to allow attaching tags to the existing process flow.

Was originally going to change the `return` parameter but using properties seems better from a backwards compatibility perspective (and considering some cases will never use this functionality).