### PR TITLE
Unregister break key handler on dispose

### DIFF
--- a/osu.Server.QueueProcessor/GracefulShutdownSource.cs
+++ b/osu.Server.QueueProcessor/GracefulShutdownSource.cs
@@ -39,6 +39,7 @@ namespace osu.Server.QueueProcessor
         public void Dispose()
         {
             shutdownComplete.Set();
+            Console.CancelKeyPress -= onCancelKeyPress;
         }
     }
 }


### PR DESCRIPTION
Otherwise it keeps intercepting break key presses