### PR TITLE
Fix shutdown item handling

### DIFF
--- a/osu.Server.QueueProcessor.Tests/InputOnlyQueueTests.cs
+++ b/osu.Server.QueueProcessor.Tests/InputOnlyQueueTests.cs
@@ -93,8 +93,11 @@ namespace osu.Server.QueueProcessor.Tests
                 }
             };
 
+            const int run_count = 5;
+
             // start and stop processing multiple times, checking items are in a good state each time.
-            for (int i = 0; i < 5; i++)
+
+            for (int i = 0; i < run_count; i++)
             {
                 var cts = new CancellationTokenSource();
 
@@ -114,7 +117,11 @@ namespace osu.Server.QueueProcessor.Tests
                     }
                 }, CancellationToken.None);
 
-                var receiveTask = Task.Run(() => processor.Run((cts = new CancellationTokenSource()).Token), CancellationToken.None);
+                // Ensure there are some items in the queue before starting the processor.
+                while (inFlightObjects.Count < 1000)
+                    Thread.Sleep(100);
+
+                var receiveTask = Task.Run(() => processor.Run(cts.Token), CancellationToken.None);
 
                 Thread.Sleep(1000);
 
@@ -124,8 +131,6 @@ namespace osu.Server.QueueProcessor.Tests
                 receiveTask.Wait(10000);
 
                 output.WriteLine($"Sent: {sent} In-flight: {inFlightObjects.Count} Processed: {processed}");
-
-                Assert.Equal(inFlightObjects.Count, processor.GetQueueSize());
             }
 
             var finalCts = new CancellationTokenSource(10000);

--- a/osu.Server.QueueProcessor/QueueProcessor.cs
+++ b/osu.Server.QueueProcessor/QueueProcessor.cs
@@ -165,6 +165,14 @@ namespace osu.Server.QueueProcessor
                     }
 
                     Console.WriteLine("Shutting down..");
+
+                    while (totalInFlight > 0)
+                    {
+                        Console.WriteLine($"Waiting for remaining {totalInFlight} in-flight items...");
+                        Thread.Sleep(5000);
+                    }
+
+                    Console.WriteLine("Bye!");
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-queue-processor/issues/14#issuecomment-1190197239.

I tried to make test coverage for this but it really doesn't work as it relies on the *process* being killed, not just the processor.

@notbakaneko could you please test this against your scenario if possible? I'm pretty confident in the logic so if that's a PITA to setup a local reference for testing we can deploy this to nuget and test that way.