### PR TITLE
Change default redis host to `localhost`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,6 @@ jobs:
       - name: Build
         run: dotnet build --no-restore
       - name: Test
+        env:
+          REDIS_HOST: redis
         run: dotnet test --no-restore --verbosity normal

--- a/osu.Server.QueueProcessor/QueueProcessor.cs
+++ b/osu.Server.QueueProcessor/QueueProcessor.cs
@@ -47,7 +47,7 @@ namespace osu.Server.QueueProcessor
         /// An option queue to push to when finished.
         /// </summary>
         private readonly ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(
-            Environment.GetEnvironmentVariable("REDIS_HOST") ?? "redis");
+            Environment.GetEnvironmentVariable("REDIS_HOST") ?? "localhost");
 
         private long totalProcessed;
 


### PR DESCRIPTION
As discussed internally, this is more in line with the rest of our projects. In production, we always specify a `REDIS_HOST` and having `localhost` the default makes testing a touch simpler in certain cases.