### PR TITLE
Add method for publishing messages to redis channels

### DIFF
--- a/osu.Server.QueueProcessor/QueueProcessor.cs
+++ b/osu.Server.QueueProcessor/QueueProcessor.cs
@@ -233,13 +233,19 @@ namespace osu.Server.QueueProcessor
 
         /// <summary>
         /// Publishes a message to a Redis channel with the supplied <paramref name="channelName"/>.
-        /// The message will be serialised using JSON.
         /// </summary>
+        /// <remarks>
+        /// The message will be serialised using JSON.
+        /// Successful publications are tracked in Datadog, using the <paramref name="channelName"/> and the <typeparamref name="TMessage"/>'s full type name as a tag.
+        /// </remarks>
         /// <param name="channelName">The name of the Redis channel to publish to.</param>
         /// <param name="message">The message to publish to the channel.</param>
         /// <typeparam name="TMessage">The type of message to be published.</typeparam>
-        public void PublishMessage<TMessage>(string channelName, TMessage message) =>
+        public void PublishMessage<TMessage>(string channelName, TMessage message)
+        {
             redis.GetDatabase().Publish(channelName, JsonConvert.SerializeObject(message));
+            DogStatsd.Increment("messages_published", tags: new[] { $"channel:{channelName}", $"type:{typeof(TMessage).FullName}" });
+        }
 
         /// <summary>
         /// Retrieve a database connection.

--- a/osu.Server.QueueProcessor/QueueProcessor.cs
+++ b/osu.Server.QueueProcessor/QueueProcessor.cs
@@ -232,6 +232,16 @@ namespace osu.Server.QueueProcessor
         public void ClearQueue() => redis.GetDatabase().KeyDelete(QueueName);
 
         /// <summary>
+        /// Publishes a message to a Redis channel with the supplied <paramref name="channelName"/>.
+        /// The message will be serialised using JSON.
+        /// </summary>
+        /// <param name="channelName">The name of the Redis channel to publish to.</param>
+        /// <param name="message">The message to publish to the channel.</param>
+        /// <typeparam name="TMessage">The type of message to be published.</typeparam>
+        public void PublishMessage<TMessage>(string channelName, TMessage message) =>
+            redis.GetDatabase().Publish(channelName, JsonConvert.SerializeObject(message));
+
+        /// <summary>
         /// Retrieve a database connection.
         /// </summary>
         public virtual MySqlConnection GetDatabaseConnection()


### PR DESCRIPTION
This is the (modest) start of a series of pulls whose end goal is to develop a full no-polling flow which can be used to deliver notifications about score processing completion to lazer clients, therefore providing a facility to complete https://github.com/ppy/osu/issues/18877. The general expected shape of the full flow can be previewed [on this diagram](https://github.com/ppy/osu/issues/18877#issuecomment-1356880170).

It's mostly just one method, that is going to be used further in `osu-queue-score-statistics`. The rationale of exposing it is roughly the following:

- Other queue operations are already similarly exposed
- StackExchange.Redis' `ConnectionMultiplexer` is [intended for reuse](https://stackexchange.github.io/StackExchange.Redis/Basics.html), so I see little basis to instantiate local instances in consumer projects
- There is a bit of glue code (JSON serialisation, observability) that can be offered out-of-the-box if this is placed here.