### PR TITLE
add `QueueConfiguration.JsonSerializerSettings`

### DIFF
--- a/osu.Server.QueueProcessor/QueueConfiguration.cs
+++ b/osu.Server.QueueProcessor/QueueConfiguration.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace osu.Server.QueueProcessor
 {
     public class QueueConfiguration
@@ -34,5 +36,10 @@ namespace osu.Server.QueueProcessor
         /// Setting above 1 will allow processing in batches (see <see cref="QueueProcessor{T}.ProcessResults"/>).
         /// </summary>
         public int BatchSize { get; set; } = 1;
+
+        /// <summary>
+        /// Serialization settings to use when deserializing items from redis.
+        /// </summary>
+        public JsonSerializerSettings? JsonSerializerSettings { get; set; } = null;
     }
 }

--- a/osu.Server.QueueProcessor/QueueProcessor.cs
+++ b/osu.Server.QueueProcessor/QueueProcessor.cs
@@ -118,7 +118,7 @@ namespace osu.Server.QueueProcessor
 
                             // null or empty check is required for redis 6.x. 7.x reports `null` instead.
                             foreach (var redisItem in redisItems.Where(i => !i.IsNullOrEmpty))
-                                items.Add(JsonConvert.DeserializeObject<T>(redisItem) ?? throw new InvalidOperationException("Dequeued item could not be deserialised."));
+                                items.Add(JsonConvert.DeserializeObject<T>(redisItem, config.JsonSerializerSettings) ?? throw new InvalidOperationException("Dequeued item could not be deserialised."));
 
                             if (items.Count == 0)
                             {


### PR DESCRIPTION
Needed the ability to specify a `TypeNameHandling` option when deserializing. Figure this is a good thing to have configurable anyway.

Wasn't sure if this would work better as a class-level property. Put it in `QueueConfiguration` for now.