### PR TITLE
Remove bountysource from README.md and add opencollective

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ A lightweight redis-backed message queue processor
 
 # Contributing
 
-Contributions can be made via pull requests to this repository. We hope to credit and reward larger contributions via a [bounty system](https://www.bountysource.com/teams/ppy). If you're unsure of what you can help with, check out the [list of open issues](https://github.com/ppy/osu-queue-processor/issues).
+Contributions can be made via pull requests to this repository. If you're unsure of what you can help with, check out the [list of open issues](https://github.com/ppy/osu-queue-processor/issues).
 
 Note that while we already have certain standards in place, nothing is set in stone. If you have an issue with the way code is structured; with any libraries we are using; with any processes involved with contributing, *please* bring it up. I welcome all feedback so we can make contributing to this project as pain-free as possible.
+
+We love to reward quality contributions. If you have made a large contribution, or are a regular contributor, you are welcome to [submit an expense via opencollective](https://opencollective.com/ppy/expenses/new). If you have any questions, feel free to [reach out to peppy](mailto:pe@ppy.sh) before doing so.
 
 # Licence
 


### PR DESCRIPTION
This repo had a dead link to a bountysource page. I have removed it and added a link to the new opencollective page.