### PR TITLE
Fix exception handling when multiple items are involved

### DIFF
--- a/osu.Server.QueueProcessor.Tests/BatchProcessorTests.cs
+++ b/osu.Server.QueueProcessor.Tests/BatchProcessorTests.cs
@@ -209,6 +209,7 @@ namespace osu.Server.QueueProcessor.Tests
             processor.Error += (exception, item) =>
             {
                 Assert.NotNull(exception);
+                Assert.Equal(exception, item.Exception);
 
                 gotCorrectExceptionForItem1 |= Equals(item.Data, obj1.Data) && exception.Message == "1";
                 gotCorrectExceptionForItem2 |= Equals(item.Data, obj2.Data) && exception.Message == "2";

--- a/osu.Server.QueueProcessor.Tests/TestBatchProcessor.cs
+++ b/osu.Server.QueueProcessor.Tests/TestBatchProcessor.cs
@@ -21,7 +21,14 @@ namespace osu.Server.QueueProcessor.Tests
         {
             foreach (var item in items)
             {
-                Received?.Invoke(item);
+                try
+                {
+                    Received?.Invoke(item);
+                }
+                catch (Exception e)
+                {
+                    item.Exception = e;
+                }
             }
         }
 

--- a/osu.Server.QueueProcessor/QueueItem.cs
+++ b/osu.Server.QueueProcessor/QueueItem.cs
@@ -12,11 +12,21 @@ namespace osu.Server.QueueProcessor
     [Serializable]
     public abstract class QueueItem
     {
+        [IgnoreDataMember]
+        private bool failed;
+
         /// <summary>
         /// Set to <c>true</c> to mark this item is failed. This will cause it to be retried.
         /// </summary>
         [IgnoreDataMember]
-        public bool Failed { get; set; }
+        public bool Failed
+        {
+            get => failed || Exception != null;
+            set => failed = value;
+        }
+
+        [IgnoreDataMember]
+        public Exception? Exception { get; set; }
 
         /// <summary>
         /// The number of times processing this item has been retried. Handled internally by <see cref="QueueProcessor{T}"/>.

--- a/osu.Server.QueueProcessor/QueueProcessor.cs
+++ b/osu.Server.QueueProcessor/QueueProcessor.cs
@@ -145,7 +145,13 @@ namespace osu.Server.QueueProcessor
 
                                             Interlocked.Increment(ref consecutiveErrors);
 
-                                            Error?.Invoke(item.Exception, item);
+                                            try
+                                            {
+                                                Error?.Invoke(item.Exception, item);
+                                            }
+                                            catch
+                                            {
+                                            }
 
                                             if (item.Exception != null)
                                                 SentrySdk.CaptureException(item.Exception);


### PR DESCRIPTION
@smoogipoo brought up concern that exception handling was nothing short of fucked. A failure in a batch would be attributed to every item in that batch, causing potential re-runs of queue items which didn't actually fail.