### PR TITLE
Fix inverted DB pooling value

### DIFF
--- a/osu.Server.QueueProcessor/DatabaseAccess.cs
+++ b/osu.Server.QueueProcessor/DatabaseAccess.cs
@@ -25,8 +25,7 @@ namespace osu.Server.QueueProcessor
                 string user = (Environment.GetEnvironmentVariable("DB_USER") ?? "root");
                 string password = (Environment.GetEnvironmentVariable("DB_PASS") ?? string.Empty);
                 string name = (Environment.GetEnvironmentVariable("DB_NAME") ?? "osu");
-                bool pooling = string.Equals(Environment.GetEnvironmentVariable("DB_POOLING"), Boolean.FalseString, StringComparison.InvariantCultureIgnoreCase)
-                               && Environment.GetEnvironmentVariable("DB_POOLING") != "0";
+                bool pooling = Environment.GetEnvironmentVariable("DB_POOLING") != "0";
                 int maxPoolSize = int.Parse(Environment.GetEnvironmentVariable("DB_MAX_POOL_SIZE") ?? "100");
 
                 string passwordString = string.IsNullOrEmpty(password) ? string.Empty : $"Password={password};";


### PR DESCRIPTION
The condition is currently equivalent to `if (str == "False" && str != "0")`, i.e.:
- default => `false`
- `"true"` (let's assume regardless of capitalisation, though that's not the case in practice) => `false`
- `"1"` => `false`
- `"0"` => `false`
- `"false"` => `true`

Let's... not do this whole other parsing thingamajig. We haven't needed it until now.