### PR TITLE
Add support for blocking pop instead of polling

### DIFF
--- a/osu.Server.QueueProcessor/QueueConfiguration.cs
+++ b/osu.Server.QueueProcessor/QueueConfiguration.cs
@@ -34,5 +34,14 @@ namespace osu.Server.QueueProcessor
         /// Setting above 1 will allow processing in batches (see <see cref="QueueProcessor{T}.ProcessResults"/>).
         /// </summary>
         public int BatchSize { get; set; } = 1;
+
+        /// <summary>
+        /// When enabled, uses <c>BRPOP</c> to wait for items instead of polling with <c>RPOP</c>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="BatchSize"/> is ignored when this is enabled.
+        /// <see cref="TimeBetweenPolls"/> is still used as a delay for when processor is overloaded.
+        /// </remarks>
+        public bool UseBlockingPop { get; set; } = false;
     }
 }

--- a/osu.Server.QueueProcessor/QueueProcessor.cs
+++ b/osu.Server.QueueProcessor/QueueProcessor.cs
@@ -48,10 +48,19 @@ namespace osu.Server.QueueProcessor
 
         private readonly Lazy<IDatabase> redis = new Lazy<IDatabase>(() => RedisAccess.GetConnection().GetDatabase());
 
+        private readonly Lazy<IDatabase> blockingRedis = new Lazy<IDatabase>(() => RedisAccess.GetConnection().GetDatabase());
+
         /// <summary>
         /// Access redis instance.
         /// </summary>
         protected IDatabase Redis => redis.Value;
+
+        /// <summary>
+        /// Allows access to a separate redis instance (connection) dedicated to blocking calls.
+        /// Must not be accessed from more than one thread. Currently used only in <see cref="Run"/>.
+        /// This is a workaround for <c>StackExchange.Redis</c> not offering support for operations like <c>BRPOP</c>.
+        /// </summary>
+        private IDatabase BlockingRedis => blockingRedis.Value;
 
         private long totalProcessed;
 
@@ -100,20 +109,38 @@ namespace osu.Server.QueueProcessor
 
                         try
                         {
+                            // avoid processing too many items at once
                             if (totalInFlight >= config.MaxInFlightItems || consecutiveErrors > config.ErrorThreshold)
                             {
                                 Thread.Sleep(config.TimeBetweenPolls);
                                 continue;
                             }
 
-                            var redisItems = Redis.ListRightPop(QueueName, config.BatchSize);
+                            RedisValue[] redisItems;
 
-                            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract (https://github.com/StackExchange/StackExchange.Redis/issues/2697)
-                            // queue doesn't exist.
-                            if (redisItems == null)
+                            if (config.UseBlockingPop)
                             {
-                                Thread.Sleep(config.TimeBetweenPolls);
-                                continue;
+                                // timeout in seconds, can't be higher than the Redis library timeout (default is 5 seconds)
+                                const string timeout = "1";
+
+                                RedisResult redisResult = BlockingRedis.Execute("BRPOP", QueueName, timeout);
+
+                                if (redisResult.IsNull)
+                                    continue;
+
+                                redisItems = [(RedisValue)redisResult[1]];
+                            }
+                            else
+                            {
+                                redisItems = Redis.ListRightPop(QueueName, config.BatchSize);
+
+                                // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract (https://github.com/StackExchange/StackExchange.Redis/issues/2697)
+                                // queue doesn't exist.
+                                if (redisItems == null)
+                                {
+                                    Thread.Sleep(config.TimeBetweenPolls);
+                                    continue;
+                                }
                             }
 
                             List<T> items = new List<T>();

--- a/osu.Server.QueueProcessor/QueueProcessor.cs
+++ b/osu.Server.QueueProcessor/QueueProcessor.cs
@@ -110,7 +110,7 @@ namespace osu.Server.QueueProcessor
                         try
                         {
                             // avoid processing too many items at once
-                            if (totalInFlight >= config.MaxInFlightItems || consecutiveErrors > config.ErrorThreshold)
+                            if (totalInFlight >= config.MaxInFlightItems)
                             {
                                 Thread.Sleep(config.TimeBetweenPolls);
                                 continue;

--- a/osu.Server.QueueProcessor/QueueProcessor.cs
+++ b/osu.Server.QueueProcessor/QueueProcessor.cs
@@ -49,13 +49,6 @@ namespace osu.Server.QueueProcessor
         private readonly Lazy<IDatabase> redis = new Lazy<IDatabase>(() => RedisAccess.GetConnection().GetDatabase());
 
         /// <summary>
-        /// Separate redis instance (connection) dedicated to blocking calls.
-        /// Must not be accessed from more than one thread. Currently used only in <see cref="Run"/>.
-        /// This is a workaround for <c>StackExchange.Redis</c> not offering support for operations like <c>BRPOP</c>.
-        /// </summary>
-        private readonly Lazy<IDatabase> blockingRedis = new Lazy<IDatabase>(() => RedisAccess.GetConnection().GetDatabase());
-
-        /// <summary>
         /// Access redis instance.
         /// </summary>
         protected IDatabase Redis => redis.Value;
@@ -92,6 +85,9 @@ namespace osu.Server.QueueProcessor
         /// <param name="cancellation">An optional cancellation token.</param>
         public void Run(CancellationToken cancellation = default)
         {
+            // dedicated redis connection for the BRPOP path, workaround for StackExchange.Redis not offering blocking operations
+            var blockingRedis = new Lazy<IDatabase>(() => RedisAccess.GetConnection().GetDatabase());
+
             using (SentrySdk.Init(setupSentry))
             using (new Timer(_ => outputStats(), null, TimeSpan.Zero, TimeSpan.FromSeconds(5)))
             using (var cts = new GracefulShutdownSource(cancellation))
@@ -118,7 +114,7 @@ namespace osu.Server.QueueProcessor
 
                             if (config.UseBlockingPop)
                             {
-                                // timeout in seconds, can't be higher than the Redis library timeout (default is 5 seconds)
+                                // timeout in seconds, can't be higher than StackExchange.Redis timeout (default is 5 seconds)
                                 const string timeout = "1";
 
                                 RedisResult redisResult = blockingRedis.Value.Execute("BRPOP", QueueName, timeout);

--- a/osu.Server.QueueProcessor/QueueProcessor.cs
+++ b/osu.Server.QueueProcessor/QueueProcessor.cs
@@ -48,19 +48,17 @@ namespace osu.Server.QueueProcessor
 
         private readonly Lazy<IDatabase> redis = new Lazy<IDatabase>(() => RedisAccess.GetConnection().GetDatabase());
 
+        /// <summary>
+        /// Separate redis instance (connection) dedicated to blocking calls.
+        /// Must not be accessed from more than one thread. Currently used only in <see cref="Run"/>.
+        /// This is a workaround for <c>StackExchange.Redis</c> not offering support for operations like <c>BRPOP</c>.
+        /// </summary>
         private readonly Lazy<IDatabase> blockingRedis = new Lazy<IDatabase>(() => RedisAccess.GetConnection().GetDatabase());
 
         /// <summary>
         /// Access redis instance.
         /// </summary>
         protected IDatabase Redis => redis.Value;
-
-        /// <summary>
-        /// Allows access to a separate redis instance (connection) dedicated to blocking calls.
-        /// Must not be accessed from more than one thread. Currently used only in <see cref="Run"/>.
-        /// This is a workaround for <c>StackExchange.Redis</c> not offering support for operations like <c>BRPOP</c>.
-        /// </summary>
-        private IDatabase BlockingRedis => blockingRedis.Value;
 
         private long totalProcessed;
 
@@ -123,7 +121,7 @@ namespace osu.Server.QueueProcessor
                                 // timeout in seconds, can't be higher than the Redis library timeout (default is 5 seconds)
                                 const string timeout = "1";
 
-                                RedisResult redisResult = BlockingRedis.Execute("BRPOP", QueueName, timeout);
+                                RedisResult redisResult = blockingRedis.Value.Execute("BRPOP", QueueName, timeout);
 
                                 if (redisResult.IsNull)
                                     continue;


### PR DESCRIPTION
Adds support for blocking pop to avoid `RPOP` spam in scenarios where we want low latency.
The timeout is one second and can't be higher than `StackExchange.Redis`  timeout which should be 5 seconds by default.
Needs a separate connection because of the blocking nature. The connection should only be used internally and in a single thread.