### PR TITLE
De-dupe updated `beatmapset_id`s

### DIFF
--- a/osu.Server.QueueProcessor/BeatmapStatusWatcher.cs
+++ b/osu.Server.QueueProcessor/BeatmapStatusWatcher.cs
@@ -64,7 +64,7 @@ namespace osu.Server.QueueProcessor
 
                 return new BeatmapUpdates
                 {
-                    BeatmapSetIDs = items.Select(i => i.beatmapset_id).ToArray(),
+                    BeatmapSetIDs = items.Select(i => i.beatmapset_id).Distinct().ToArray(),
                     LastProcessedQueueID = items.LastOrDefault()?.queue_id ?? lastQueueId.Value
                 };
             }


### PR DESCRIPTION
See [internal discussion](https://discord.com/channels/90072389919997952/983550677794050108/1481936986309918750).


Just to reduce bandwidth on `server-spectator` marginally when receiving beatmap updates.